### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,10 +13,10 @@ RoxygenNote: 7.1.2
 Biarch: true
 Depends: R (>= 3.4.0)
 Imports: methods, Rcpp (>= 0.12.0), RcppParallel (>= 5.0.1), rstan (>=
-        2.18.1), rstantools (>= 2.1.1), LaplacesDemon (>= 16.1.6)
+        2.26.0), rstantools (>= 2.1.1), LaplacesDemon (>= 16.1.6)
 LinkingTo: BH (>= 1.66.0), Rcpp (>= 0.12.0), RcppEigen (>= 0.3.3.3.0),
-        RcppParallel (>= 5.0.1), rstan (>= 2.18.1), StanHeaders (>=
-        2.18.0)
+        RcppParallel (>= 5.0.1), rstan (>= 2.26.0), StanHeaders (>=
+        2.26.0)
 SystemRequirements: GNU make
 Suggests: rmarkdown, knitr
 VignetteBuilder: knitr

--- a/inst/stan/Correlated_basic.stan
+++ b/inst/stan/Correlated_basic.stan
@@ -2,7 +2,7 @@
 data {
   int<lower=0> n_i;
   int<lower=0> n_k;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Correlated_x.stan
+++ b/inst/stan/Correlated_x.stan
@@ -3,7 +3,7 @@ data {
   int<lower=0> n_i;
   int<lower=0> n_k;
   matrix[n_i, n_k] x;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Correlated_x_zglobal.stan
+++ b/inst/stan/Correlated_x_zglobal.stan
@@ -5,7 +5,7 @@ data {
   int<lower=0> z_global_size;
   matrix[n_i, n_k] x;
   matrix[n_i, z_global_size] z_global;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Correlated_x_zsubpop.stan
+++ b/inst/stan/Correlated_x_zsubpop.stan
@@ -5,7 +5,7 @@ data {
   int<lower=0> z_subpop_size;
   matrix[n_i, n_k] x;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Correlated_x_zsubpop_zglobal.stan
+++ b/inst/stan/Correlated_x_zsubpop_zglobal.stan
@@ -7,7 +7,7 @@ data {
   matrix[n_i, n_k] x;
   matrix[n_i, z_global_size] z_global;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Correlated_zglobal.stan
+++ b/inst/stan/Correlated_zglobal.stan
@@ -4,7 +4,7 @@ data {
   int<lower=0> n_k;
   int<lower=0> z_global_size;
   matrix[n_i, z_global_size] z_global;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Correlated_zsubpop.stan
+++ b/inst/stan/Correlated_zsubpop.stan
@@ -4,7 +4,7 @@ data {
   int<lower=0> n_k;
   int<lower=0> z_subpop_size;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Correlated_zsubpop_zglobal.stan
+++ b/inst/stan/Correlated_zsubpop_zglobal.stan
@@ -6,7 +6,7 @@ data {
   int<lower=0> z_subpop_size;
   matrix[n_i, z_global_size] z_global;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Overdispersed_Stan.stan
+++ b/inst/stan/Overdispersed_Stan.stan
@@ -2,7 +2,7 @@
 data {
   int<lower=0> n_i;
   int<lower=0> n_k;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 

--- a/inst/stan/Uncorrelated_basic.stan
+++ b/inst/stan/Uncorrelated_basic.stan
@@ -2,7 +2,7 @@
 data {
   int<lower=0> n_i;
   int<lower=0> n_k;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Uncorrelated_x.stan
+++ b/inst/stan/Uncorrelated_x.stan
@@ -3,7 +3,7 @@ data {
   int<lower=0> n_i;
   int<lower=0> n_k;
   matrix[n_i, n_k] x;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Uncorrelated_x_zglobal.stan
+++ b/inst/stan/Uncorrelated_x_zglobal.stan
@@ -5,7 +5,7 @@ data {
   int<lower=0> z_global_size;
   matrix[n_i, n_k] x;
   matrix[n_i, z_global_size] z_global;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Uncorrelated_x_zsubpop.stan
+++ b/inst/stan/Uncorrelated_x_zsubpop.stan
@@ -5,7 +5,7 @@ data {
   int<lower=0> z_subpop_size;
   matrix[n_i, n_k] x;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Uncorrelated_x_zsubpop_zglobal.stan
+++ b/inst/stan/Uncorrelated_x_zsubpop_zglobal.stan
@@ -7,7 +7,7 @@ data {
   matrix[n_i, n_k] x;
   matrix[n_i, z_global_size] z_global;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Uncorrelated_zglobal.stan
+++ b/inst/stan/Uncorrelated_zglobal.stan
@@ -4,7 +4,7 @@ data {
   int<lower=0> n_k;
   int<lower=0> z_global_size;
   matrix[n_i, z_global_size] z_global;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Uncorrelated_zsubpop.stan
+++ b/inst/stan/Uncorrelated_zsubpop.stan
@@ -4,7 +4,7 @@ data {
   int<lower=0> n_k;
   int<lower=0> z_subpop_size;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {

--- a/inst/stan/Uncorrelated_zsubpop_zglobal.stan
+++ b/inst/stan/Uncorrelated_zsubpop_zglobal.stan
@@ -6,7 +6,7 @@ data {
   int<lower=0> z_subpop_size;
   matrix[n_i, z_global_size] z_global;
   matrix[n_i, z_subpop_size] z_subpop;
-  int y[n_i,n_k];
+  array[n_i,n_k] int y;
 }
 
 parameters {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
